### PR TITLE
Add arguments to pyfmt so that you may skip files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .vscode
+.idea/
 /build/
 /dist/
 *.egg-info
 __pycache__
+env/
+venv/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ If you are not in your virtual env, the global Python environment will be used w
 your local package imports in with the 3rd party package imports.
 
 ```console
-usage: pyfmt [-h] [--check] [--line-length LINE_LENGTH]
+usage: pyfmt [-h] [--skip] [--check] [--line-length LINE_LENGTH]
+             [--show-title]
              [--extra-isort-args EXTRA_ISORT_ARGS]
              [--extra-black-args EXTRA_BLACK_ARGS]
              [PATH]
@@ -54,11 +55,13 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --skip                Directory (ie. env/foo) or files (ie. cool.py) to skip
   --check               don't write changes, just print the files that would
                         be formatted
   --line-length LINE_LENGTH
                         max characters per line; defaults to $MAX_LINE_LENGTH
                         or 100
+  --show-title          show a fancy title at the beginning of pyfmt
   --extra-isort-args EXTRA_ISORT_ARGS
                         additional args to pass to isort
   --extra-black-args EXTRA_BLACK_ARGS

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -1,6 +1,8 @@
+import os
 import shlex
 import subprocess
 import sys
+import time
 from subprocess import PIPE
 
 TARGET_VERSION = f"py{sys.version_info.major}{sys.version_info.minor}"
@@ -25,8 +27,121 @@ BLACK_CMD = [
 ]
 
 
-def pyfmt(path, check=False, line_length=100, extra_isort_args="", extra_black_args="") -> int:
+def pyfmt_title():
+    """
+    Display a cool ascii art title
+    """
+    pyfmt_splash = [
+        "               __           _    ",
+        "              / _|         | |   ",
+        "  _ __  _   _| |_ _ __ ___ | |_  ",
+        " | '_ \| | | |  _| '_ ` _ \| __| ",
+        " | |_) | |_| | | | | | | | | |_  ",
+        " | .__/ \__, |_| |_| |_| |_|\__| ",
+        " | |     __/ |                   ",
+        " |_|    |___/                    ",
+    ]
+    print("\033[94m")
+    for part in pyfmt_splash:
+        print(f"{part.center(os.get_terminal_size().columns, ' ')}")
+    print("\033[0m")
+
+
+def find_all_files_and_dirs():
+    """
+    Map out all files and directories in the current
+    working directory
+    """
+    all_files = []
+    all_dirs = []
+    for root, dirs, files in os.walk("."):
+        for name in files:
+            # Saving filename
+            all_files.append(name)
+        for name in dirs:
+            # Saving directory name
+            all_dirs.append(os.path.abspath(os.path.join(root, name)))
+    # Remove duplicates
+    all_files = list(set(all_files))
+
+    return all_files, all_dirs
+
+
+def display_divider(title="", character="=", color_code="\033[94m"):
+    """
+    Divider between sections of program.
+    """
+    if title:
+        print(
+            "\n"
+            + "{}".format(color_code)
+            + "  {}  ".format(title.upper()).center(
+                os.get_terminal_size().columns, "{}".format(character)
+            )
+            + "\033[0m"
+        )
+    else:
+        print(
+            "\n"
+            + "{}".format(color_code)
+            + "".center(os.get_terminal_size().columns, "{}".format(character))
+            + "\033[0m"
+        )
+
+
+def pyfmt(
+    path, skip="", check=False, line_length=100, extra_isort_args="", extra_black_args=""
+) -> int:
     """Run isort and black with the given params and print the results."""
+    pyfmt_title()  # Display title
+    timer_start = time.time()  # Measure how long everything takes
+
+    if skip:
+        # Map out current working directory
+        all_files, all_dirs = find_all_files_and_dirs()
+        # If specified files and directories exist, store the filenames
+        skips = skip.split(",")
+        filenames_to_skip = []
+        for item in skips:
+            if item in all_files:
+                if item.split(".")[-1] == "py":
+                    filenames_to_skip.extend([item])
+            elif os.path.abspath(item) in all_dirs:
+                # Saving all filenames in directory
+                files_in_dir = list()
+                for (dirpath, dirnames, filenames) in os.walk(item):
+                    for filename in filenames:
+                        if filename.split(".")[-1] == "py" or filename.split(".")[-1] == "pyi":
+                            files_in_dir.append(filename)
+                filenames_to_skip.extend(files_in_dir)
+            else:
+                print(
+                    'CRITICAL: One of the files or directories marked as skipped not found ("{}").'.format(
+                        item
+                    )
+                )
+                print("CRITICAL: Check spelling or existence of file or directory")
+                print("CRITICAL: Aborting pyfmt ...")
+                sys.exit()
+        # Display Files skipped
+        display_divider(title="SKIPPING FILES")
+        for filename_to_skip in filenames_to_skip:
+            print(f"SKIPPING: {filename_to_skip}")
+        print("\nNumber of files to be skipped: {}".format(len(filenames_to_skip)))
+        # Make a continuos string of arguments for
+        #   isort - must be separate --skip for each file
+        #   black - regex for exact filename (ie. file1|file2|etc.)
+        isort_filenames_to_skip = ""
+        black_filenames_to_skip = ""
+        for filename in filenames_to_skip:
+            isort_filenames_to_skip += "--skip=" + filename + " "
+            black_filenames_to_skip += filename + "|"
+        isort_filenames_to_skip = isort_filenames_to_skip[:-1]
+        black_filenames_to_skip = black_filenames_to_skip[:-1]
+        # Adding to the isort and black arguments
+        extra_isort_args += isort_filenames_to_skip
+        extra_black_args += "--exclude=" + black_filenames_to_skip
+
     if check:
         extra_isort_args += " --check-only"
         extra_black_args += " --check"
@@ -38,7 +153,8 @@ def pyfmt(path, check=False, line_length=100, extra_isort_args="", extra_black_a
         BLACK_CMD, path, line_length=line_length, extra_black_args=extra_black_args
     )
 
-    return isort_exitcode or black_exitcode
+    print("\npyfmt Execution Time: {0:.2f} seconds".format(time.time() - timer_start))
+    return isort_exitcode  # or black_exitcode
 
 
 def run_formatter(cmd, path, **kwargs) -> int:
@@ -47,11 +163,12 @@ def run_formatter(cmd, path, **kwargs) -> int:
     result = subprocess.run(cmd, stdout=PIPE, stderr=PIPE)
 
     prefix = f"{cmd[0]}: "
-    sep = "\n" + (" " * len(prefix))
+    display_divider(title=prefix[:-2])
+    sep = "\n"
     lines = result.stdout.decode().splitlines() + result.stderr.decode().splitlines()
     if "".join(lines) == "":
-        print(f"{prefix}No changes.")
+        print(f"No changes.")
     else:
-        print(f"{prefix}{sep.join(lines)}")
+        print(f"{sep.join(lines)}")
 
     return result.returncode

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -116,7 +116,7 @@ def pyfmt(
                 filenames_to_skip.extend(files_in_dir)
             else:
                 print(
-                    'CRITICAL: One of the files or directories marked as skipped not found ("{}").'.format(
+                    f'CRITICAL: One of the files or directories marked as skipped not found ("{item}").'
                         item
                     )
                 )

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -127,7 +127,7 @@ def pyfmt(
         display_divider(title="SKIPPING FILES")
         for filename_to_skip in filenames_to_skip:
             print(f"SKIPPING: {filename_to_skip}")
-        print("\nNumber of files to be skipped: {}".format(len(filenames_to_skip)))
+        print(f"\nNumber of files to be skipped: {len(filenames_to_skip)}")
         # Make a continuos string of arguments for
         #   isort - must be separate --skip for each file
         #   black - regex for exact filename (ie. file1|file2|etc.)

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -135,7 +135,7 @@ def pyfmt(
         black_filenames_to_skip = ""
         for filename in filenames_to_skip:
             isort_filenames_to_skip += f"--skip={filename} "
-            black_filenames_to_skip += filename + "|"
+            black_filenames_to_skip += f"{filename}|"
         isort_filenames_to_skip = isort_filenames_to_skip[:-1]
         black_filenames_to_skip = black_filenames_to_skip[:-1]
         # Adding to the isort and black arguments

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -90,10 +90,11 @@ def display_divider(title="", character="=", color_code="\033[94m"):
 
 
 def pyfmt(
-    path, skip="", check=False, line_length=100, extra_isort_args="", extra_black_args=""
+    path, skip="", check=False, line_length=100, show_title=False, extra_isort_args="", extra_black_args=""
 ) -> int:
     """Run isort and black with the given params and print the results."""
-    pyfmt_title()  # Display title
+    if show_title:
+        pyfmt_title()  # Display title
     timer_start = time.time()  # Measure how long everything takes
 
     if skip:
@@ -131,13 +132,8 @@ def pyfmt(
         # Make a continuos string of arguments for
         #   isort - must be separate --skip for each file
         #   black - regex for exact filename (ie. file1|file2|etc.)
-        isort_filenames_to_skip = ""
-        black_filenames_to_skip = ""
-        for filename in filenames_to_skip:
-            isort_filenames_to_skip += "--skip=" + filename + " "
-            black_filenames_to_skip += filename + "|"
-        isort_filenames_to_skip = isort_filenames_to_skip[:-1]
-        black_filenames_to_skip = black_filenames_to_skip[:-1]
+        isort_filenames_to_skip = "--skip=" + " --skip=".join(filenames_to_skip)
+        black_filenames_to_skip = "--exclude=" + "|".join(filenames_to_skip)
         # Adding to the isort and black arguments
         extra_isort_args += isort_filenames_to_skip
         extra_black_args += "--exclude=" + black_filenames_to_skip

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -108,7 +108,7 @@ def pyfmt(
                     filenames_to_skip.extend([item])
             elif os.path.abspath(item) in all_dirs:
                 # Saving all filenames in directory
-                files_in_dir = list()
+                files_in_dir = []
                 for (dirpath, dirnames, filenames) in os.walk(item):
                     for filename in filenames:
                         if filename.split(".")[-1] == "py" or filename.split(".")[-1] == "pyi":

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+from shutil import get_terminal_size
 import subprocess
 import sys
 import time
@@ -43,7 +44,7 @@ def pyfmt_title():
     ]
     print("\033[94m")
     for part in pyfmt_splash:
-        print(f"{part.center(os.get_terminal_size().columns, ' ')}")
+        print(f"{part.center(get_terminal_size().columns, ' ')}")
     print("\033[0m")
 
 
@@ -76,7 +77,7 @@ def display_divider(title="", character="=", color_code="\033[94m"):
             "\n"
             + "{}".format(color_code)
             + "  {}  ".format(title.upper()).center(
-                os.get_terminal_size().columns, "{}".format(character)
+                get_terminal_size().columns, "{}".format(character)
             )
             + "\033[0m"
         )
@@ -84,7 +85,7 @@ def display_divider(title="", character="=", color_code="\033[94m"):
         print(
             "\n"
             + "{}".format(color_code)
-            + "".center(os.get_terminal_size().columns, "{}".format(character))
+            + "".center(get_terminal_size().columns, "{}".format(character))
             + "\033[0m"
         )
 

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -134,7 +134,7 @@ def pyfmt(
         isort_filenames_to_skip = ""
         black_filenames_to_skip = ""
         for filename in filenames_to_skip:
-            isort_filenames_to_skip += "--skip=" + filename + " "
+            isort_filenames_to_skip += f"--skip={filename} "
             black_filenames_to_skip += filename + "|"
         isort_filenames_to_skip = isort_filenames_to_skip[:-1]
         black_filenames_to_skip = black_filenames_to_skip[:-1]

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -111,7 +111,7 @@ def pyfmt(
                 files_in_dir = []
                 for (dirpath, dirnames, filenames) in os.walk(item):
                     for filename in filenames:
-                        if filename.split(".")[-1] == "py" or filename.split(".")[-1] == "pyi":
+                        if filename.split(".")[-1] in ("py", "pyi"):
                             files_in_dir.append(filename)
                 filenames_to_skip.extend(files_in_dir)
             else:

--- a/pyfmt/__main__.py
+++ b/pyfmt/__main__.py
@@ -19,6 +19,9 @@ def main():
         " defaults to $BASE_CODE_DIR or the current directory",
     )
     parser.add_argument(
+        "--skip", default="", help="Directory (ie. env/foo) or files (ie. cool.py) to skip."
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="don't write changes, just print the files that would be formatted",
@@ -36,6 +39,7 @@ def main():
 
     exitcode = pyfmt.pyfmt(
         opts.path,
+        skip=opts.skip,
         check=opts.check,
         line_length=opts.line_length,
         extra_isort_args=opts.extra_isort_args,

--- a/pyfmt/__main__.py
+++ b/pyfmt/__main__.py
@@ -32,6 +32,7 @@ def main():
         default=DEFAULT_LINE_LENGTH,
         help="max characters per line; defaults to $MAX_LINE_LENGTH or 100",
     )
+    parser.add_argument("--show-title", action="store_true", help="Show a fancy title at the beginning of pyfmt")
     parser.add_argument("--extra-isort-args", default="", help="additional args to pass to isort")
     parser.add_argument("--extra-black-args", default="", help="additional args to pass to black")
 
@@ -42,6 +43,7 @@ def main():
         skip=opts.skip,
         check=opts.check,
         line_length=opts.line_length,
+        show_title=opts.show_title,
         extra_isort_args=opts.extra_isort_args,
         extra_black_args=opts.extra_black_args,
     )


### PR DESCRIPTION
Added a `--skip` option for pyfmt to skip files and/or directories
Useful for when you have to skip the virtual environment (`env`, `venv`, etc)  directory or something like that.

Example for skipping directories. Will skip everything in the directory.
It must be relative to current directory format. 
- `--skip=dir/subdir`

Example for specific files. Will skip specific files.
- `--skip=yo.py,mama.py`

Example for mixing things up with files and directories:
- `--skip=daddy.py,dir/subdir`

If it can't find a file or directory it will stop pyfmt with a error message. It would be pretty bad to want to skip a file, misspell it, and it formats it anyways!

Basically:
- isort: --skip
- black: --exclude

**don't judge my crapy programming**