### PR TITLE
Minor improvements and a bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ since these options are all reliant on the status of your git working tree and i
 usage: pyfmt [-h] [-x SELECT] [-c] [--line-length N]
              [--commit [ARG [ARG ...]]] [--commit-msg [MSG [MSG ...]]]
              [--extra-isort-args ARGS] [--extra-black-args ARGS]
-             [PATH]
+             [PATH [PATH ...]]
 
 positional arguments:
-  PATH                  path to base directory where pyfmt will be run
-                        (default: $BASE_CODE_DIR | '.')
+  PATH                  file and directory paths where pyfmt will be run
+                        (default: $BASE_CODE_DIR | ['.'])
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -72,7 +72,9 @@ optional arguments:
                         > modified  files in the index, working tree, and
                                     untracked files
                         > head      files changed in HEAD
-                        > local     files changed locally but not upstream
+                        > local     files changed locally but not upstream; if
+                                    upstream branch is missing,
+                                    fallback to `all`
   -c, --check           don't write changes, just print the files that would be
                         formatted
   --line-length N       max characters per line (default: $MAX_LINE_LENGTH |

--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -38,7 +38,7 @@ SELECTOR_MAP = {
 
 
 def pyfmt(
-    path: str,
+    paths: List[str],
     selector: str = "all",
     line_length: int = 100,
     check: bool = False,
@@ -50,9 +50,9 @@ def pyfmt(
     """Run isort and black with the given params and print the results."""
     # Filter path according to given ``selector``.
     select_files = SELECTOR_MAP[selector]
-    files = tuple(select_files(path))
+    files = tuple(select_files(paths))
     if not files:
-        print("No files need formatting.")
+        print("No files were selected.")
         return 0
 
     if check:

--- a/pyfmt/__main__.py
+++ b/pyfmt/__main__.py
@@ -23,9 +23,9 @@ def main():
     parser = FormattedHelpArgumentParser(prog="pyfmt")
     parser.add_argument(
         "path",
-        nargs="?",
+        nargs="*",
         envvar="BASE_CODE_DIR",
-        default=".",
+        default=["."],
         metavar="PATH",
         help="path to base directory where pyfmt will be run",
     )

--- a/pyfmt/__main__.py
+++ b/pyfmt/__main__.py
@@ -9,7 +9,8 @@ SELECT_CHOICES = {
     "staged": "files in the index",
     "modified": "files in the index, working tree, and untracked files",
     "head": "files changed in HEAD",
-    "local": "files changed locally but not upstream",
+    "local": "files changed locally but not upstream;"
+    " if upstream branch is missing, fallback to `all`",
 }
 
 COMMIT_CHOICES = {
@@ -27,7 +28,7 @@ def main():
         envvar="BASE_CODE_DIR",
         default=["."],
         metavar="PATH",
-        help="path to base directory where pyfmt will be run",
+        help="file and directory paths where pyfmt will be run",
     )
     parser.add_choices_argument(
         "-x",

--- a/pyfmt/select.py
+++ b/pyfmt/select.py
@@ -51,9 +51,9 @@ class GitStatusCode:
         return self.index == "R"
 
 
-def _iter_changed(path) -> Iterator[Tuple[GitStatusCode, str]]:
+def _iter_changed(paths: Iterable[str]) -> Iterator[Tuple[GitStatusCode, str]]:
     """Iterate over .py files in the index and working tree that aren't deleted."""
-    output = _sh("git", "status", "--porcelain", path)
+    output = _sh("git", "status", "--porcelain", *paths)
     for line in output.splitlines():
         xy, line = line[:2], line[2:].strip()
         code = GitStatusCode(*xy)
@@ -65,9 +65,9 @@ def _iter_changed(path) -> Iterator[Tuple[GitStatusCode, str]]:
             yield code, file
 
 
-def _iter_committed(path: str, commits: str) -> Iterator[str]:
+def _iter_committed(paths: Iterable[str], commits: str) -> Iterator[str]:
     """Iterate over .py files in the given commit ("x") or range ("x..y")."""
-    output = _sh("git", "--no-pager", "diff", "--numstat", commits, "--", path)
+    output = _sh("git", "--no-pager", "diff", "--numstat", commits, "--", *paths)
     for line in output.splitlines():
         file = line.strip().rsplit(maxsplit=1)[-1]
         if file.endswith(".py"):

--- a/pyfmt/select.py
+++ b/pyfmt/select.py
@@ -7,17 +7,17 @@ __all__ = ["select_staged", "select_modified", "select_head", "select_local", "s
 
 
 def select_staged(paths: Iterable[str]) -> Iterator[str]:
-    return (file for code, file in _iter_changed(paths) if code.index_has_changes())
+    yield from (file for code, file in _iter_changed(paths) if code.index_has_changes())
 
 
 def select_modified(paths: Iterable[str]) -> Iterator[str]:
-    return (
+    yield from (
         file for code, file in _iter_changed(paths) if code.has_changes() or code.is_untracked()
     )
 
 
 def select_head(paths: Iterable[str]) -> Iterator[str]:
-    return _iter_committed(paths, "HEAD^1..HEAD")
+    yield from _iter_committed(paths, "HEAD^1..HEAD")
 
 
 def select_local(paths: Iterable[str]) -> Iterator[str]:
@@ -86,4 +86,6 @@ def _iter_committed(paths: Iterable[str], commits: str) -> Iterator[str]:
 
 
 def _sh(*args: str) -> str:
-    return subprocess.run(args, stdout=subprocess.PIPE, check=True).stdout.decode()
+    return subprocess.run(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+    ).stdout.decode()


### PR DESCRIPTION
- [x] Fix bug where `pyfmt --select local` fails if there is no upstream branch (e.g. if you're creating the upstream branch with `git push -u`). Now `--select local` will fallback to `--select all` if there is no upstream branch.
- [x] Add support for multiple `PATH` values, e.g. `pyfmt src/ tests/`.
- [x] If `add_argument` is called with `envvar`, and the argument stores a list of values (e.g. with `nargs="*"` or `action="append"`), the environment variable will be parsed as a list of values using `shlex.split`. This was necessary to support multiple values for `PATH`, since the `PATH` argument uses `envvar="BASE_CODE_DIR"`.